### PR TITLE
Fixed a crash with paths containing trailing spaces.

### DIFF
--- a/Logic/RepositoryWatcher.cs
+++ b/Logic/RepositoryWatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -62,7 +62,7 @@ namespace GitViz.Logic
 
         public void Dispose()
         {
-            _watcher.Dispose();
+            _watcher?.Dispose();
         }
 
         ~RepositoryWatcher()

--- a/Logic/ViewModel.cs
+++ b/Logic/ViewModel.cs
@@ -34,7 +34,7 @@ namespace GitViz.Logic
             get { return _repositoryPath; }
             set
             {
-                _repositoryPath = value;
+                _repositoryPath = value.TrimEnd();
                 if (IsValidGitRepository(_repositoryPath))
                 {
                     OnPropertyChanged("WindowTitle");


### PR DESCRIPTION
The app crashes when pasting a path with a space (e.g. a copy/paste from Total Commander).
Directory.Exists removes trailing spaces before checking the folder, but the FileSystemWatcher does not.