### PR TITLE
Migrate QuickGraph to QuikGraph and GraphSharp to GraphShape.

### DIFF
--- a/Logic/CommitEdge.cs
+++ b/Logic/CommitEdge.cs
@@ -1,4 +1,4 @@
-﻿using QuickGraph;
+using QuikGraph;
 
 namespace GitViz.Logic
 {

--- a/Logic/CommitGraph.cs
+++ b/Logic/CommitGraph.cs
@@ -1,4 +1,4 @@
-﻿using QuickGraph;
+using QuikGraph;
 
 namespace GitViz.Logic
 {

--- a/Logic/Logic.csproj
+++ b/Logic/Logic.csproj
@@ -30,23 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GraphSharp">
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="GraphSharp.Controls">
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.Controls.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Data">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Graphviz">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Graphviz.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Serialization">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
+    <Reference Include="QuikGraph">
+      <HintPath>..\packages\QuikGraph.2.1.0\lib\net45\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Logic/packages.config
+++ b/Logic/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GraphSharp" version="1.1.0.0" targetFramework="net45" />
-  <package id="QuickGraph" version="3.6.61119.7" targetFramework="net45" />
+  <package id="QuikGraph" version="2.1.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net45" />

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is not a day-to-day visualizing tool for big, active repositories. It's opt
 
 ### How it works
 
-Shells out to `git.exe`, and then renders it with the excellent [GraphSharp](http://graphsharp.codeplex.com).
+Shells out to `git.exe`, and then renders it with the excellent [GraphShape](https://github.com/KeRNeLith/GraphShape).
 
 ### FAQ
 #### How can I remove dangling commits?

--- a/UI/CommitGraphLayout.cs
+++ b/UI/CommitGraphLayout.cs
@@ -1,5 +1,5 @@
-﻿using GitViz.Logic;
-using GraphSharp.Controls;
+using GitViz.Logic;
+using GraphShape.Controls;
 
 namespace UI
 {

--- a/UI/MainWindow.xaml
+++ b/UI/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:logic="clr-namespace:GitViz.Logic;assembly=GitViz.Logic"
         xmlns:ui="clr-namespace:UI"
-        xmlns:graphsharp="clr-namespace:GraphSharp.Controls;assembly=GraphSharp.Controls"
+        xmlns:graphshape="clr-namespace:GraphShape.Controls;assembly=GraphShape.Controls"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         mc:Ignorable="d" d:DesignHeight="600" d:DesignWidth="400"
@@ -46,10 +46,10 @@
             x:Key="VertexTemplateSelector"
             CommitTemplate="{StaticResource CommitTemplate}"
             ReferenceTemplate="{StaticResource ReferenceTemplate}" />
-        <Style TargetType="{x:Type graphsharp:VertexControl}">
+        <Style TargetType="{x:Type graphshape:VertexControl}">
             <Setter Property="Template">
                 <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type graphsharp:VertexControl}">
+                    <ControlTemplate TargetType="{x:Type graphshape:VertexControl}">
                         <ContentPresenter Content="{TemplateBinding Vertex}" ContentTemplateSelector="{StaticResource VertexTemplateSelector}" />
                     </ControlTemplate>
                 </Setter.Value>
@@ -72,7 +72,7 @@
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
             <ui:CommitGraphLayout x:Name="graph"
                 Graph="{Binding Path=Graph}"
-                LayoutAlgorithmType="EfficientSugiyama"
+                LayoutAlgorithmType="Sugiyama"
                 OverlapRemovalAlgorithmType="FSA"
                 HighlightAlgorithmType="Simple"
                 Margin="20"

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -37,23 +37,14 @@
     <ApplicationIcon>readify.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GraphSharp">
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.dll</HintPath>
+    <Reference Include="GraphShape">
+      <HintPath>..\packages\GraphShape.1.0.0\lib\net45\GraphShape.dll</HintPath>
     </Reference>
-    <Reference Include="GraphSharp.Controls">
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.Controls.dll</HintPath>
+    <Reference Include="GraphShape.Controls">
+      <HintPath>..\packages\GraphShape.Controls.1.0.0\lib\net45\GraphShape.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="QuickGraph">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Data">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Graphviz">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Graphviz.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Serialization">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
+    <Reference Include="QuikGraph">
+      <HintPath>..\packages\QuikGraph.2.1.0\lib\net45\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/UI/packages.config
+++ b/UI/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GraphSharp" version="1.1.0.0" targetFramework="net45" />
-  <package id="QuickGraph" version="3.6.61119.7" targetFramework="net45" />
+  <package id="GraphShape" version="1.0.0" targetFramework="net45" />
+  <package id="GraphShape.Controls" version="1.0.0" targetFramework="net45" />
+  <package id="QuikGraph" version="2.1.0" targetFramework="net45" />
   <package id="WPFExtensions" version="1.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hello,

I updated the quite old QuickGraph and GraphSharp dependencies to respectively QuikGraph and GraphShape.

Those libraries are using modern C# development workflow, have been ported to .NET Core with a wider support in term of targets.
And finally they come with a huge set of unit tests that has helped to debug and fix a lot of issues in both libraries.

Since they have been built using recent toolchain they will certainly help you to port your app to .NET Core (I faced issue with the old version of those libraries while tying to use the Microsoft.NET.Sdk.WindowsDesktop for WPF applications). Those reworked libraries allow to get rid of such issues.

Here are the links to both libraries:
- [QuikGraph](https://github.com/KeRNeLith/QuikGraph)
- [GraphShape](https://github.com/KeRNeLith/GraphShape)